### PR TITLE
Replace Optional references with values

### DIFF
--- a/VkCppGenerator.cpp
+++ b/VkCppGenerator.cpp
@@ -1881,7 +1881,7 @@ void writeFunctionHeader(std::ofstream & ofs, std::string const& indentation, st
             if (commandData.arguments[i].optional)
             {
               type[pos] = ' ';
-              type = "vk::Optional<" + trimEnd(type) + "> const &";
+              type = "vk::Optional<" + trimEnd(type) + ">";
             }
             else
             {


### PR DESCRIPTION
Because Optional itself contains nothing but a pointer, passing it by reference is gratuitous indirection.

Unless I'm missing something here?