### PR TITLE
add algorithm for std::find

### DIFF
--- a/VkCppGenerator.cpp
+++ b/VkCppGenerator.cpp
@@ -2988,6 +2988,7 @@ int main( int argc, char **argv )
       << "#define VK_CPP_H_" << std::endl
       << std::endl
       << "#include <array>" << std::endl
+      << "#include <algorithm>" << std::endl
       << "#include <cassert>" << std::endl
       << "#include <cstdint>" << std::endl
       << "#include <cstring>" << std::endl


### PR DESCRIPTION
Building on Linux with GCC:

vk_cpp.hpp:449:10: error: ‘find’ is not a member of ‘std’
